### PR TITLE
judy, Feat:: navigationMenu에 메뉴 크기랑 간격에 따른 height 기본값 추가 #62

### DIFF
--- a/lib/widgets/navigationMenu/navigation_menu.dart
+++ b/lib/widgets/navigationMenu/navigation_menu.dart
@@ -8,7 +8,7 @@ class SFNavigationMenu extends StatefulWidget {
     this.width,
     required this.height,
     this.menuSize,
-    this.menuSpacing = 5,
+    this.menuSpacing = 10,
     this.backgroundColor,
     this.focusedBackgroundColor,
     this.textColor,
@@ -115,6 +115,9 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
             ishover[index] = value;
             setState(() {});
           },
+          borderRadius: BorderRadius.all(
+            Radius.circular(widget.radius),
+          ),
           child: Ink(
             width: widget.menuSize,
             height: widget.menuSize,

--- a/lib/widgets/navigationMenu/navigation_menu.dart
+++ b/lib/widgets/navigationMenu/navigation_menu.dart
@@ -22,9 +22,11 @@ class SFNavigationMenu extends StatefulWidget {
     this.physics,
     this.initialIndex,
     this.textStyle,
+    this.disabledPaddingIndex,
+    this.disabledHoverIndex,
   });
   // 리스트 메뉴
-  final List<String> menu;
+  final List<Widget> menu;
 
   // 가로 넓이
   final double? width;
@@ -77,6 +79,12 @@ class SFNavigationMenu extends StatefulWidget {
   // 메뉴 텍스트 스타일
   final TextStyle? textStyle;
 
+  // padding 적용 안 시킬 menu index List
+  final List<int>? disabledPaddingIndex;
+
+  // hover효과 적용 안 시킬 menu index List
+  final List<int>? disabledHoverIndex;
+
   @override
   State<SFNavigationMenu> createState() => _SFNavigationMenu();
 }
@@ -87,12 +95,16 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
   double? widthSpacing;
   double? heightSpacing;
   double? height;
+  List<int> _disabledPaddingIndex = [];
+  List<int> _disabledHoverIndex = [];
 
   @override
   void initState() {
     super.initState();
     ishover = List.generate(widget.menu.length, (index) => false);
     focusedChild = widget.initialIndex;
+    _disabledPaddingIndex = widget.disabledPaddingIndex ?? [];
+    _disabledHoverIndex = widget.disabledHoverIndex ?? [];
     spacing();
   }
 
@@ -118,7 +130,9 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
               focusedChild = index;
               setState(() {});
             },
-            hoverColor: widget.focusedBackgroundColor ?? SFColor.primary5,
+            hoverColor: _disabledHoverIndex.contains(index)
+                ? Colors.transparent
+                : widget.focusedBackgroundColor ?? SFColor.primary5,
             onHover: (value) {
               ishover[index] = value;
               setState(() {});
@@ -129,9 +143,12 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
             child: Ink(
               width: widget.menuSize,
               height: widget.menuSize,
-              padding: widget.padding ?? const EdgeInsets.all(12.0),
+              padding: widget.padding ??
+                  EdgeInsets.all(
+                      _disabledPaddingIndex.contains(index) ? 0 : 12.0),
               decoration: BoxDecoration(
-                  color: focusedChild == index
+                  color: focusedChild == index &&
+                          !_disabledHoverIndex.contains(index)
                       ? widget.focusedBackgroundColor ?? SFColor.primary5
                       : widget.backgroundColor,
                   border: Border.all(
@@ -139,15 +156,16 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
                       color: widget.outlineColor ?? Colors.transparent),
                   borderRadius: BorderRadius.circular(widget.radius)),
               child: Center(
-                child: Text(
-                  widget.menu[index],
+                child: DefaultTextStyle(
                   style: widget.textStyle ??
                       SFTextStyle.b3M16(
-                          color: ishover[index]
+                          color: ishover[index] &&
+                                  !_disabledHoverIndex.contains(index)
                               ? widget.focusedTextColor ?? SFColor.primary80
                               : focusedChild == index
                                   ? widget.focusedTextColor ?? SFColor.primary80
                                   : widget.textColor ?? Colors.black),
+                  child: widget.menu[index],
                 ),
               ),
             ),
@@ -169,7 +187,8 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
       case Axis.vertical:
         heightSpacing = widget.menuSpacing;
         height = (heightSpacing! + (widget.menuSize ?? fontSize + 26)) *
-            widget.menu.length;
+                widget.menu.length -
+            (26 * _disabledPaddingIndex.length);
         break;
       case Axis.horizontal:
         widthSpacing = widget.menuSpacing;

--- a/lib/widgets/navigationMenu/navigation_menu.dart
+++ b/lib/widgets/navigationMenu/navigation_menu.dart
@@ -6,7 +6,7 @@ class SFNavigationMenu extends StatefulWidget {
     super.key,
     required this.menu,
     this.width,
-    required this.height,
+    this.height,
     this.menuSize,
     this.menuSpacing = 10,
     this.backgroundColor,
@@ -21,6 +21,7 @@ class SFNavigationMenu extends StatefulWidget {
     this.padding,
     this.physics,
     this.initialIndex,
+    this.textStyle,
   });
   // 리스트 메뉴
   final List<String> menu;
@@ -29,13 +30,13 @@ class SFNavigationMenu extends StatefulWidget {
   final double? width;
 
   // 높이
-  final double height;
+  final double? height;
 
   // 메뉴 가로 크기
   final double? menuSize;
 
   // 메뉴 사이 spacing
-  final double? menuSpacing;
+  final double menuSpacing;
 
   // 메뉴 배경 색
   final Color? backgroundColor;
@@ -73,6 +74,9 @@ class SFNavigationMenu extends StatefulWidget {
   // 사적 인덱스
   final int? initialIndex;
 
+  // 메뉴 텍스트 스타일
+  final TextStyle? textStyle;
+
   @override
   State<SFNavigationMenu> createState() => _SFNavigationMenu();
 }
@@ -82,6 +86,8 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
   List<bool> ishover = [];
   double? widthSpacing;
   double? heightSpacing;
+  double? height;
+
   @override
   void initState() {
     super.initState();
@@ -94,69 +100,80 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
   Widget build(BuildContext context) {
     return SizedBox(
       width: widget.width,
-      height: widget.height,
-      child: ListView.separated(
-        physics: widget.physics ?? const NeverScrollableScrollPhysics(),
-        scrollDirection: widget.direction,
-        itemCount: widget.menu.length,
-        itemBuilder: (context, index) => InkWell(
-          splashColor: Colors.transparent, // 클릭할 때 나오는 효과 색상
-          highlightColor: Colors.transparent, // 클릭 유지 시 나오는 효과 색상
-          onTap: () {
-            if (widget.onTap != null) {
-              widget.onTap!(index);
-            }
-            focusedChild = index;
-            setState(() {});
-          },
-          hoverColor: widget.focusedBackgroundColor ?? SFColor.primary5,
-          onHover: (value) {
-            ishover[index] = value;
-            setState(() {});
-          },
-          borderRadius: BorderRadius.all(
-            Radius.circular(widget.radius),
-          ),
-          child: Ink(
-            width: widget.menuSize,
-            height: widget.menuSize,
-            padding: widget.padding ?? const EdgeInsets.all(12.0),
-            decoration: BoxDecoration(
-                color: focusedChild == index
-                    ? widget.focusedBackgroundColor ?? SFColor.primary5
-                    : widget.backgroundColor,
-                border: Border.all(
-                    width: widget.outlineWidth ?? 0,
-                    color: widget.outlineColor ?? Colors.transparent),
-                borderRadius: BorderRadius.circular(widget.radius)),
-            child: Center(
-              child: Text(
-                widget.menu[index],
-                style: SFTextStyle.b3M16(
-                    color: ishover[index]
-                        ? widget.focusedTextColor ?? SFColor.primary80
-                        : focusedChild == index
-                            ? widget.focusedTextColor ?? SFColor.primary80
-                            : widget.textColor ?? Colors.black),
+      height: widget.height ?? height,
+      child: ScrollConfiguration(
+        behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
+        child: ListView.separated(
+          padding: EdgeInsets.zero,
+          physics: widget.physics ?? const NeverScrollableScrollPhysics(),
+          scrollDirection: widget.direction,
+          itemCount: widget.menu.length,
+          itemBuilder: (context, index) => InkWell(
+            splashColor: Colors.transparent,
+            highlightColor: Colors.transparent,
+            onTap: () {
+              if (widget.onTap != null) {
+                widget.onTap!(index);
+              }
+              focusedChild = index;
+              setState(() {});
+            },
+            hoverColor: widget.focusedBackgroundColor ?? SFColor.primary5,
+            onHover: (value) {
+              ishover[index] = value;
+              setState(() {});
+            },
+            borderRadius: BorderRadius.all(
+              Radius.circular(widget.radius),
+            ),
+            child: Ink(
+              width: widget.menuSize,
+              height: widget.menuSize,
+              padding: widget.padding ?? const EdgeInsets.all(12.0),
+              decoration: BoxDecoration(
+                  color: focusedChild == index
+                      ? widget.focusedBackgroundColor ?? SFColor.primary5
+                      : widget.backgroundColor,
+                  border: Border.all(
+                      width: widget.outlineWidth ?? 0,
+                      color: widget.outlineColor ?? Colors.transparent),
+                  borderRadius: BorderRadius.circular(widget.radius)),
+              child: Center(
+                child: Text(
+                  widget.menu[index],
+                  style: widget.textStyle ??
+                      SFTextStyle.b3M16(
+                          color: ishover[index]
+                              ? widget.focusedTextColor ?? SFColor.primary80
+                              : focusedChild == index
+                                  ? widget.focusedTextColor ?? SFColor.primary80
+                                  : widget.textColor ?? Colors.black),
+                ),
               ),
             ),
           ),
-        ),
-        separatorBuilder: (context, index) => SizedBox(
-          width: widthSpacing,
-          height: heightSpacing,
+          separatorBuilder: (context, index) => SizedBox(
+            width: widthSpacing,
+            height: heightSpacing,
+          ),
         ),
       ),
     );
   }
 
   spacing() {
+    double fontSize =
+        (widget.textStyle != null ? widget.textStyle!.fontSize ?? 16 : 16) +
+            4.8;
     switch (widget.direction) {
       case Axis.vertical:
         heightSpacing = widget.menuSpacing;
+        height = (heightSpacing! + (widget.menuSize ?? fontSize + 26)) *
+            widget.menu.length;
         break;
       case Axis.horizontal:
         widthSpacing = widget.menuSpacing;
+        height = fontSize + 26;
         break;
     }
   }

--- a/lib/widgets/navigationMenu/navigation_menu.dart
+++ b/lib/widgets/navigationMenu/navigation_menu.dart
@@ -90,19 +90,19 @@ class SFNavigationMenu extends StatefulWidget {
 }
 
 class _SFNavigationMenu extends State<SFNavigationMenu> {
-  int? focusedChild;
-  List<bool> ishover = [];
-  double? widthSpacing;
-  double? heightSpacing;
-  double? height;
+  int? _focusedIndex;
+  List<bool> _ishover = [];
+  double? _widthSpacing;
+  double? _heightSpacing;
+  double? _height;
   List<int> _disabledPaddingIndex = [];
   List<int> _disabledHoverIndex = [];
 
   @override
   void initState() {
     super.initState();
-    ishover = List.generate(widget.menu.length, (index) => false);
-    focusedChild = widget.initialIndex;
+    _ishover = List.generate(widget.menu.length, (index) => false);
+    _focusedIndex = widget.initialIndex;
     _disabledPaddingIndex = widget.disabledPaddingIndex ?? [];
     _disabledHoverIndex = widget.disabledHoverIndex ?? [];
     spacing();
@@ -112,7 +112,7 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
   Widget build(BuildContext context) {
     return SizedBox(
       width: widget.width,
-      height: widget.height ?? height,
+      height: widget.height ?? _height,
       child: ScrollConfiguration(
         behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
         child: ListView.separated(
@@ -127,14 +127,14 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
               if (widget.onTap != null) {
                 widget.onTap!(index);
               }
-              focusedChild = index;
+              _focusedIndex = index;
               setState(() {});
             },
             hoverColor: _disabledHoverIndex.contains(index)
                 ? Colors.transparent
                 : widget.focusedBackgroundColor ?? SFColor.primary5,
             onHover: (value) {
-              ishover[index] = value;
+              _ishover[index] = value;
               setState(() {});
             },
             borderRadius: BorderRadius.all(
@@ -147,7 +147,7 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
                   EdgeInsets.all(
                       _disabledPaddingIndex.contains(index) ? 0 : 12.0),
               decoration: BoxDecoration(
-                  color: focusedChild == index &&
+                  color: _focusedIndex == index &&
                           !_disabledHoverIndex.contains(index)
                       ? widget.focusedBackgroundColor ?? SFColor.primary5
                       : widget.backgroundColor,
@@ -159,10 +159,10 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
                 child: DefaultTextStyle(
                   style: widget.textStyle ??
                       SFTextStyle.b3M16(
-                          color: ishover[index] &&
+                          color: _ishover[index] &&
                                   !_disabledHoverIndex.contains(index)
                               ? widget.focusedTextColor ?? SFColor.primary80
-                              : focusedChild == index
+                              : _focusedIndex == index
                                   ? widget.focusedTextColor ?? SFColor.primary80
                                   : widget.textColor ?? Colors.black),
                   child: widget.menu[index],
@@ -171,8 +171,8 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
             ),
           ),
           separatorBuilder: (context, index) => SizedBox(
-            width: widthSpacing,
-            height: heightSpacing,
+            width: _widthSpacing,
+            height: _heightSpacing,
           ),
         ),
       ),
@@ -185,14 +185,14 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
             4.8;
     switch (widget.direction) {
       case Axis.vertical:
-        heightSpacing = widget.menuSpacing;
-        height = (heightSpacing! + (widget.menuSize ?? fontSize + 26)) *
+        _heightSpacing = widget.menuSpacing;
+        _height = (_heightSpacing! + (widget.menuSize ?? fontSize + 26)) *
                 widget.menu.length -
             (26 * _disabledPaddingIndex.length);
         break;
       case Axis.horizontal:
-        widthSpacing = widget.menuSpacing;
-        height = fontSize + 26;
+        _widthSpacing = widget.menuSpacing;
+        _height = fontSize + 26;
         break;
     }
   }

--- a/lib/widgets/navigationMenu/navigation_menu.dart
+++ b/lib/widgets/navigationMenu/navigation_menu.dart
@@ -7,8 +7,7 @@ class SFNavigationMenu extends StatefulWidget {
     required this.menu,
     this.width,
     required this.height,
-    this.menuWidth,
-    this.menuHeigh,
+    this.menuSize,
     this.menuSpacing = 5,
     this.backgroundColor,
     this.focusedBackgroundColor,
@@ -31,11 +30,8 @@ class SFNavigationMenu extends StatefulWidget {
   // 높이
   final double height;
 
-  // 메뉴 가로 넓이
-  final double? menuWidth;
-
-  // 메뉴 높이
-  final double? menuHeigh;
+  // 메뉴 가로 크기
+  final double? menuSize;
 
   // 메뉴 사이 spacing
   final double? menuSpacing;
@@ -110,9 +106,9 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
             ishover[index] = value;
             setState(() {});
           },
-          child: Container(
-            width: widget.menuWidth,
-            height: widget.menuHeigh,
+          child: Ink(
+            width: widget.menuSize,
+            height: widget.menuSize,
             padding: widget.padding ?? const EdgeInsets.all(12.0),
             decoration: BoxDecoration(
                 color: focusedChild == index
@@ -122,14 +118,16 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
                     width: widget.outlineWidth ?? 0,
                     color: widget.outlineColor ?? Colors.transparent),
                 borderRadius: BorderRadius.circular(widget.radius)),
-            child: Text(
-              widget.menu[index],
-              style: SFTextStyle.b3M16(
-                  color: ishover[index]
-                      ? widget.focusedTextColor ?? SFColor.primary80
-                      : focusedChild == index
-                          ? widget.focusedTextColor ?? SFColor.primary80
-                          : widget.textColor ?? Colors.black),
+            child: Center(
+              child: Text(
+                widget.menu[index],
+                style: SFTextStyle.b3M16(
+                    color: ishover[index]
+                        ? widget.focusedTextColor ?? SFColor.primary80
+                        : focusedChild == index
+                            ? widget.focusedTextColor ?? SFColor.primary80
+                            : widget.textColor ?? Colors.black),
+              ),
             ),
           ),
         ),

--- a/lib/widgets/navigationMenu/navigation_menu.dart
+++ b/lib/widgets/navigationMenu/navigation_menu.dart
@@ -28,13 +28,13 @@ class SFNavigationMenu extends StatefulWidget {
   // 리스트 메뉴
   final List<Widget> menu;
 
-  // 가로 넓이
+  // 가로 너비
   final double? width;
 
   // 높이
   final double? height;
 
-  // 메뉴 가로 크기
+  // 메뉴 크기
   final double? menuSize;
 
   // 메뉴 사이 spacing

--- a/lib/widgets/navigationMenu/navigation_menu.dart
+++ b/lib/widgets/navigationMenu/navigation_menu.dart
@@ -3,7 +3,7 @@ import 'package:sfac_design_flutter/sfac_design_flutter.dart';
 
 class SFNavigationMenu extends StatefulWidget {
   const SFNavigationMenu({
-    Key? key,
+    super.key,
     required this.menu,
     this.width,
     required this.height,
@@ -20,9 +20,8 @@ class SFNavigationMenu extends StatefulWidget {
     this.onTap,
     this.padding,
     this.physics,
-    this.initialIndex = 0,
-  })  : assert(initialIndex <= menu.length && initialIndex >= 0),
-        super(key: key);
+    this.initialIndex,
+  });
   // 리스트 메뉴
   final List<String> menu;
 
@@ -72,7 +71,7 @@ class SFNavigationMenu extends StatefulWidget {
   final ScrollPhysics? physics;
 
   // 사적 인덱스
-  final int initialIndex;
+  final int? initialIndex;
 
   @override
   State<SFNavigationMenu> createState() => _SFNavigationMenu();

--- a/lib/widgets/navigationMenu/navigation_menu.dart
+++ b/lib/widgets/navigationMenu/navigation_menu.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:sfac_design_flutter/sfac_design_flutter.dart';
+
+class SFNavigationMenu extends StatefulWidget {
+  const SFNavigationMenu({
+    super.key,
+    required this.menu,
+    this.width,
+    required this.height,
+    this.menuWidth,
+    this.menuHeigh,
+    this.menuSpacing = 5,
+    this.backgroundColor,
+    this.focusedBackgroundColor,
+    this.textColor,
+    this.focusedTextColor,
+    this.outlineColor,
+    this.radius = 10,
+    this.outlineWidth,
+    this.direction = Axis.horizontal,
+    this.onTap,
+    this.padding,
+    this.physics,
+  });
+  // 리스트 메뉴
+  final List<String> menu;
+
+  // 가로 넓이
+  final double? width;
+
+  // 높이
+  final double height;
+
+  // 메뉴 가로 넓이
+  final double? menuWidth;
+
+  // 메뉴 높이
+  final double? menuHeigh;
+
+  // 메뉴 사이 spacing
+  final double? menuSpacing;
+
+  // 메뉴 배경 색
+  final Color? backgroundColor;
+
+  // 포커스된 메뉴 배경 색
+  final Color? focusedBackgroundColor;
+
+  // 메뉴 텍스트 색
+  final Color? textColor;
+
+  // 포커스된 메뉴 텍스트 색
+  final Color? focusedTextColor;
+
+  // 테두리 색
+  final Color? outlineColor;
+
+  // 테두리 곡선
+  final double radius;
+
+  // 테두리 굵기
+  final double? outlineWidth;
+
+  // 메뉴 정렬 방향
+  final Axis direction;
+
+  // 메뉴 클릭 함수
+  final Function(int)? onTap;
+
+  // 메뉴 패딩
+  final EdgeInsetsGeometry? padding;
+
+  // 네비게이션 메뉴 ScrollPhysics
+  final ScrollPhysics? physics;
+
+  @override
+  State<SFNavigationMenu> createState() => _SFNavigationMenu();
+}
+
+class _SFNavigationMenu extends State<SFNavigationMenu> {
+  int focusedChild = 0;
+  List<bool> ishover = [];
+  @override
+  void initState() {
+    super.initState();
+    ishover = List.generate(widget.menu.length, (index) => false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: widget.width,
+      height: widget.height,
+      child: ListView.separated(
+        physics: widget.physics ?? const NeverScrollableScrollPhysics(),
+        scrollDirection: widget.direction,
+        itemCount: widget.menu.length,
+        itemBuilder: (context, index) => InkWell(
+          splashColor: Colors.transparent,
+          highlightColor: Colors.transparent,
+          onTap: () {
+            if (widget.onTap != null) {
+              widget.onTap!(index);
+            }
+            focusedChild = index;
+            setState(() {});
+          },
+          hoverColor: widget.focusedBackgroundColor ?? SFColor.primary5,
+          onHover: (value) {
+            ishover[index] = value;
+            setState(() {});
+          },
+          child: Container(
+            width: widget.menuWidth,
+            height: widget.menuHeigh,
+            padding: widget.padding ?? const EdgeInsets.all(12.0),
+            decoration: BoxDecoration(
+                color: focusedChild == index
+                    ? widget.focusedBackgroundColor ?? SFColor.primary5
+                    : widget.backgroundColor,
+                border: Border.all(
+                    width: widget.outlineWidth ?? 0,
+                    color: widget.outlineColor ?? Colors.transparent),
+                borderRadius: BorderRadius.circular(widget.radius)),
+            child: Text(
+              widget.menu[index],
+              style: SFTextStyle.b3M16(
+                  color: ishover[index]
+                      ? widget.focusedTextColor ?? SFColor.primary80
+                      : focusedChild == index
+                          ? widget.focusedTextColor ?? SFColor.primary80
+                          : widget.textColor ?? Colors.black),
+            ),
+          ),
+        ),
+        separatorBuilder: (context, index) =>
+            SizedBox(width: widget.menuSpacing),
+      ),
+    );
+  }
+}

--- a/lib/widgets/navigationMenu/navigation_menu.dart
+++ b/lib/widgets/navigationMenu/navigation_menu.dart
@@ -3,7 +3,7 @@ import 'package:sfac_design_flutter/sfac_design_flutter.dart';
 
 class SFNavigationMenu extends StatefulWidget {
   const SFNavigationMenu({
-    super.key,
+    Key? key,
     required this.menu,
     this.width,
     required this.height,
@@ -20,7 +20,9 @@ class SFNavigationMenu extends StatefulWidget {
     this.onTap,
     this.padding,
     this.physics,
-  });
+    this.initialIndex = 0,
+  })  : assert(initialIndex <= menu.length && initialIndex >= 0),
+        super(key: key);
   // 리스트 메뉴
   final List<String> menu;
 
@@ -69,17 +71,24 @@ class SFNavigationMenu extends StatefulWidget {
   // 네비게이션 메뉴 ScrollPhysics
   final ScrollPhysics? physics;
 
+  // 사적 인덱스
+  final int initialIndex;
+
   @override
   State<SFNavigationMenu> createState() => _SFNavigationMenu();
 }
 
 class _SFNavigationMenu extends State<SFNavigationMenu> {
-  int focusedChild = 0;
+  int? focusedChild;
   List<bool> ishover = [];
+  double? widthSpacing;
+  double? heightSpacing;
   @override
   void initState() {
     super.initState();
     ishover = List.generate(widget.menu.length, (index) => false);
+    focusedChild = widget.initialIndex;
+    spacing();
   }
 
   @override
@@ -92,8 +101,8 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
         scrollDirection: widget.direction,
         itemCount: widget.menu.length,
         itemBuilder: (context, index) => InkWell(
-          splashColor: Colors.transparent,
-          highlightColor: Colors.transparent,
+          splashColor: Colors.transparent, // 클릭할 때 나오는 효과 색상
+          highlightColor: Colors.transparent, // 클릭 유지 시 나오는 효과 색상
           onTap: () {
             if (widget.onTap != null) {
               widget.onTap!(index);
@@ -131,9 +140,22 @@ class _SFNavigationMenu extends State<SFNavigationMenu> {
             ),
           ),
         ),
-        separatorBuilder: (context, index) =>
-            SizedBox(width: widget.menuSpacing),
+        separatorBuilder: (context, index) => SizedBox(
+          width: widthSpacing,
+          height: heightSpacing,
+        ),
       ),
     );
+  }
+
+  spacing() {
+    switch (widget.direction) {
+      case Axis.vertical:
+        heightSpacing = widget.menuSpacing;
+        break;
+      case Axis.horizontal:
+        widthSpacing = widget.menuSpacing;
+        break;
+    }
   }
 }


### PR DESCRIPTION
## 요약 및 목적
Navigation menu `hover` 또는 선택(클릭) 시 배경 색과 텍스트 색 변경
`onTap(p0){}` `p0`로 `menu` `index` 값을 받을 수 있다.

## 변경사항에 대한 자세한 설명
**[c797591](https://github.com/sniperfactory-official/sfac-designkit-flutter/pull/74/commits/c7975910df734362002983ed01977657786412f6)**
메뉴 크기와 간격에 따른 `height` 기본 값 설정
`height` 속성에 `required` 삭제

**[4c5a11f](https://github.com/sniperfactory-official/sfac-designkit-flutter/pull/74/commits/4c5a11f7fff08b513dbfd363ac9900ce65ad0e23)**
`menu` 데이터 타입을 `String` ->`Widget` 타입으로 변경
`disabledPaddingIndex`와 `disabledHoverIndex` 속성 추가

**[976ef3f](https://github.com/sniperfactory-official/sfac-designkit-flutter/pull/74/commits/976ef3fea40532870471d3b77a95864c6735d3c6)**
private 변수 _ 추가

 **[1354aa6](https://github.com/sniperfactory-official/sfac-designkit-flutter/pull/74/commits/1354aa6c8a2c63d9ad1e9072d0868275aedfcda5)**
가로 넓이 -> 가로 너비 주석 변경

## 리뷰어들에게 전달할 내용
확인 부탁드려요
`Row`나 `Column` 대신 `NavigatinMenu`로 사용할 수 있게 `menu` 데이터 타입을 `String`에서 `Widget`으로 데이터 타입을 변경했습니다
이에 따라 `hover` 효과와 `padding` 기능을 주고 싶지 않은 `menu` `index`를 받을 수 있게 `disabledPaddingIndex`, `disabledHoverIndex` 속성을 추가했습니다
<br/>
<br/>

```
특정 동작을 수행하는 다양한 키워드가 있지만
일단 'resolved' 혹은 'close'만 사용합니다.
ex) resolved: #issue_number (띄어쓰기 필수)
위의 예제처럼 입력할 시 merge를 할 경우 issue가 자동으로 close 됩니다
이 칸 아래에 적어주세요!
```
resolved: #62 