### PR TITLE
judy, Update:: comboBox status가 selectSearch일 때 필터 시 height이 바뀌지 않은 현상 수정

### DIFF
--- a/lib/widgets/comboBox/combo_box.dart
+++ b/lib/widgets/comboBox/combo_box.dart
@@ -223,15 +223,15 @@ class _SFComboBoxState extends State<SFComboBox> {
     super.initState();
     _selectMain = widget.menus;
     _menuBoxheight = widget.height ??
-        (widget.menus.length * widget.menuHeight +
-            (widget.menus.length > 1 ? widget.menus.length - 1 : 0) *
+        (_selectMain.length * widget.menuHeight +
+            (_selectMain.length > 1 ? _selectMain.length - 1 : 0) *
                 (widget.spacing));
   }
 
   getHeight() {
     _menuBoxheight = widget.height ??
-        (widget.menus.length * widget.menuHeight +
-            (widget.menus.length > 1 ? widget.menus.length - 1 : 0) *
+        (_selectMain.length * widget.menuHeight +
+            (_selectMain.length > 1 ? _selectMain.length - 1 : 0) *
                 (widget.spacing));
     //화면 높이
     double windowHeight = MediaQuery.of(context).size.height * 0.9;
@@ -272,15 +272,12 @@ class _SFComboBoxState extends State<SFComboBox> {
 
   filterMenu(String value) {
     if (value.isNotEmpty) {
-      setState(() {
-        _selectMain =
-            widget.menus.where((e) => e.title.contains(value)).toList();
-      });
+      _selectMain = widget.menus.where((e) => e.title.contains(value)).toList();
     } else {
-      setState(() {
-        _selectMain = widget.menus;
-      });
+      _selectMain = widget.menus;
     }
+    getHeight();
+    setState(() {});
   }
 
   void popOverlay() {


### PR DESCRIPTION
## 요약 및 목적
comboBox status가 selectSearch일 때 필터 시 height이 바뀌지 않은 현상 수정

## 변경사항에 대한 자세한 설명
filterMenu() 에 getHeight 함수 추가 setState 마지막 줄로 이동

## 리뷰어들에게 전달할 내용
확인 부탁드려요

<br/>
<br/>

```
특정 동작을 수행하는 다양한 키워드가 있지만
일단 'resolved' 혹은 'close'만 사용합니다.
ex) resolved: #issue_number (띄어쓰기 필수)
위의 예제처럼 입력할 시 merge를 할 경우 issue가 자동으로 close 됩니다
이 칸 아래에 적어주세요!
```
resloved: #83