### PR TITLE
judy, Feat:: datePicker 위젯 추가 #49

### DIFF
--- a/lib/widgets/datepicker/calendar.dart
+++ b/lib/widgets/datepicker/calendar.dart
@@ -11,7 +11,7 @@ enum SFCalendarTheme { light, dark }
 class SFCalendar extends StatefulWidget {
   const SFCalendar({
     Key? key,
-    this.status = SFCalendarStatus.range,
+    this.type = SFCalendarStatus.one,
     this.theme = SFCalendarTheme.light,
     this.initialDateList,
     this.initialDateRange,
@@ -36,7 +36,7 @@ class SFCalendar extends StatefulWidget {
   // list 선택한 날짜 리스트
   // range 선택한 기간
   // one 선택한 날짜 하나
-  final SFCalendarStatus status;
+  final SFCalendarStatus type;
 
   // 캘린터 테마 dart, light
   final SFCalendarTheme theme;
@@ -111,7 +111,7 @@ class _DatePickerWidgetState extends State<SFCalendar> {
   @override
   void initState() {
     super.initState();
-    switch (widget.status) {
+    switch (widget.type) {
       case SFCalendarStatus.list:
         _selectedDateList.addAll(widget.initialDateList ?? []);
         break;
@@ -197,7 +197,7 @@ class _DatePickerWidgetState extends State<SFCalendar> {
   }
 
   bool isRange(int index1, int index2) {
-    return widget.status == SFCalendarStatus.range &&
+    return widget.type == SFCalendarStatus.range &&
         _selectRangeStart != null &&
         _selectRangeEnd != null &&
         (_selectRangeStart!.isBefore(_calender[index1 * 7 + index2]) &&
@@ -208,7 +208,7 @@ class _DatePickerWidgetState extends State<SFCalendar> {
   }
 
   selectedDate(int index1, int index2) {
-    switch (widget.status) {
+    switch (widget.type) {
       case SFCalendarStatus.list:
         selectDate(_calender[index1 * 7 + index2]);
         if (widget.getSelectedDate != null) {
@@ -416,7 +416,7 @@ class _DatePickerWidgetState extends State<SFCalendar> {
 
   Color _dayBoxColor(DateTime date) {
     if (_isSelected) {
-      switch (widget.status) {
+      switch (widget.type) {
         case SFCalendarStatus.list:
           return _selectedDateList.indexWhere((e) =>
                       e.year == date.year &&
@@ -454,14 +454,14 @@ class _DatePickerWidgetState extends State<SFCalendar> {
   Color dayTextColor(DateTime date) {
     int overStart = 0;
     int underEnd = 0;
-    if (widget.status == SFCalendarStatus.range &&
+    if (widget.type == SFCalendarStatus.range &&
         _selectRangeStart != null &&
         _selectRangeStart != null) {
       overStart = _selectRangeStart?.compareTo(date) ?? 0;
       underEnd = _selectRangeEnd?.compareTo(date) ?? 0;
     }
     if (_isSelected) {
-      switch (widget.status) {
+      switch (widget.type) {
         case SFCalendarStatus.list:
           return _selectedDateList.indexWhere((e) =>
                       e.year == date.year &&

--- a/lib/widgets/datepicker/calendar.dart
+++ b/lib/widgets/datepicker/calendar.dart
@@ -1,0 +1,527 @@
+import 'package:flutter/material.dart';
+import 'package:sfac_design_flutter/sfac_design_flutter.dart';
+
+typedef GetSelectedDate = void Function(DateTime? start, DateTime? end,
+    List<DateTime>? selectedDateList, DateTime? selectedOne);
+
+enum SFCalendarStatus { list, range, one }
+
+enum SFCalendarTheme { light, dark }
+
+class SFCalendar extends StatefulWidget {
+  const SFCalendar({
+    Key? key,
+    this.status = SFCalendarStatus.range,
+    this.theme = SFCalendarTheme.light,
+    this.initialDateList,
+    this.initialDateRange,
+    this.initialDateOne,
+    this.backgroundColor,
+    this.textColor,
+    this.selectedColor = SFColor.primary100,
+    this.rangeColor = SFColor.primary100,
+    this.selectedTextColor,
+    this.borderRadius = const BorderRadius.all(Radius.circular(10)),
+    this.contentSize = 16,
+    this.verticalSpacing = 12,
+    this.horizontalSpacing = 12,
+    this.width,
+    this.height,
+    this.padding,
+    this.getSelectedDate,
+    this.todayMark = true,
+  })  : assert(
+            verticalSpacing >= 0 && horizontalSpacing >= 0 && contentSize > 0),
+        super(key: key);
+  final SFCalendarStatus status;
+  final SFCalendarTheme theme;
+  final List<DateTime>? initialDateList;
+  final DateTimeRange? initialDateRange;
+  final DateTime? initialDateOne;
+  final Color? backgroundColor;
+  final Color? textColor;
+  final Color selectedColor;
+  final Color rangeColor;
+  final Color? selectedTextColor;
+  final BorderRadius borderRadius;
+  final double contentSize;
+  final double verticalSpacing;
+  final double horizontalSpacing;
+  final double? width;
+  final double? height;
+  final EdgeInsetsGeometry? padding;
+  final GetSelectedDate? getSelectedDate;
+  final bool todayMark;
+
+  @override
+  State<SFCalendar> createState() => _DatePickerWidgetState();
+}
+
+class _DatePickerWidgetState extends State<SFCalendar> {
+  final List<DateTime> _calender = [];
+
+  final List<DateTime> _selectedDateList = [];
+
+  DateTime? _selectRangeStart;
+  DateTime? _selectRangeEnd;
+  DateTime? _selectOne;
+
+  late Color _selectedTextColor;
+
+  late DateTime _viewMonth;
+
+  bool _isSelected = false;
+
+  @override
+  void initState() {
+    super.initState();
+    switch (widget.status) {
+      case SFCalendarStatus.list:
+        _selectedDateList.addAll(widget.initialDateList ?? []);
+        break;
+      case SFCalendarStatus.range:
+        _selectRangeStart = widget.initialDateRange?.start;
+        _selectRangeEnd = widget.initialDateRange?.end;
+
+        break;
+      case SFCalendarStatus.one:
+        _selectOne = widget.initialDateOne;
+        break;
+    }
+    _viewMonth = DateTime.now();
+    _selectedTextColor = widget.selectedTextColor ?? Colors.white;
+    if (_selectedDateList.isEmpty &&
+        _selectRangeStart == null &&
+        _selectRangeEnd == null &&
+        _selectOne == null) {
+      _isSelected = !widget.todayMark;
+    } else {
+      _isSelected = true;
+    }
+    viewCalender();
+    setState(() {});
+  }
+
+  List<String> weekNames = ['일', '월', '화', '수', '목', '금', '토'];
+
+  void viewCalender() {
+    _calender.clear();
+
+    int startWeekDay =
+        DateTime(_viewMonth.year, _viewMonth.month, 1).weekday == 7
+            ? 0
+            : DateTime(_viewMonth.year, _viewMonth.month, 1).weekday;
+
+    for (int i = 1; i <= 42; i++) {
+      _calender
+          .add(DateTime(_viewMonth.year, _viewMonth.month, i - startWeekDay));
+    }
+  }
+
+  void goBackMonth() {
+    _viewMonth = DateTime(_viewMonth.year, _viewMonth.month - 1, 1);
+    viewCalender();
+  }
+
+  void goFrontMonth() {
+    _viewMonth = DateTime(_viewMonth.year, _viewMonth.month + 1, 1);
+    viewCalender();
+  }
+
+  void selectedOne(DateTime date) {
+    _selectOne != date ? _selectOne = date : _selectOne = null;
+  }
+
+  void selectDate(DateTime date) {
+    if (!_selectedDateList.contains(date)) {
+      _selectedDateList.add(date);
+    } else {
+      _selectedDateList.removeWhere((e) =>
+          e.year == date.year && e.month == date.month && e.day == date.day);
+    }
+  }
+
+  void selectDateRange(DateTime date) {
+    if (_selectRangeStart == null) {
+      _selectRangeStart = date;
+      return;
+    } else if (_selectRangeEnd != null) {
+      _selectRangeStart = date;
+      _selectRangeEnd = null;
+      return;
+    } else if (_selectRangeStart == date) {
+      _selectRangeStart = null;
+      return;
+    } else if (date.isBefore(_selectRangeStart!)) {
+      _selectRangeStart = date;
+      return;
+    } else if (date.isAfter(_selectRangeStart!)) {
+      _selectRangeEnd = date;
+    }
+  }
+
+  bool isRange(int index1, int index2) {
+    return widget.status == SFCalendarStatus.range &&
+        _selectRangeStart != null &&
+        _selectRangeEnd != null &&
+        (_selectRangeStart!.isBefore(_calender[index1 * 7 + index2]) &&
+            _selectRangeEnd!.isAfter(
+              _calender[index1 * 7 + index2]
+                  .add(const Duration(hours: 23, minutes: 59, seconds: 59)),
+            ));
+  }
+
+  selectedDate(int index1, int index2) {
+    switch (widget.status) {
+      case SFCalendarStatus.list:
+        selectDate(_calender[index1 * 7 + index2]);
+        if (widget.getSelectedDate != null) {
+          widget.getSelectedDate!(null, null, _selectedDateList, null);
+        }
+        break;
+      case SFCalendarStatus.range:
+        selectDateRange(_calender[index1 * 7 + index2]);
+        if (widget.getSelectedDate != null) {
+          widget.getSelectedDate!(
+              _selectRangeStart, _selectRangeEnd, null, null);
+        }
+        break;
+      case SFCalendarStatus.one:
+        selectedOne(_calender[index1 * 7 + index2]);
+        if (widget.getSelectedDate != null) {
+          widget.getSelectedDate!(null, null, null, _selectOne);
+        }
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: widget.width,
+      height: widget.height,
+      padding: widget.padding ??
+          const EdgeInsets.symmetric(
+            vertical: 20,
+            horizontal: 30,
+          ),
+      decoration: BoxDecoration(
+        borderRadius: widget.borderRadius,
+        color: widget.backgroundColor ??
+            (widget.theme == SFCalendarTheme.light
+                ? Colors.white
+                : Colors.black),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              GestureDetector(
+                onTap: () {
+                  goBackMonth();
+                  setState(() {});
+                },
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 10),
+                  child: Icon(
+                    Icons.arrow_back_ios,
+                    color: widget.textColor ??
+                        (widget.theme == SFCalendarTheme.light
+                            ? SFColor.grayScale80
+                            : Colors.white),
+                    size: widget.contentSize + 2,
+                  ),
+                ),
+              ),
+              Text(
+                '${_viewMonth.year}년 ${_viewMonth.month}월',
+                style: TextStyle(
+                  fontFamily: 'PretendardBold',
+                  fontSize: widget.contentSize + 4,
+                  color: widget.textColor ??
+                      (widget.theme == SFCalendarTheme.light
+                          ? SFColor.grayScale80
+                          : Colors.white),
+                ),
+              ),
+              GestureDetector(
+                onTap: () {
+                  goFrontMonth();
+                  setState(() {});
+                },
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 10),
+                  child: Icon(
+                    Icons.arrow_forward_ios,
+                    color: widget.textColor ??
+                        (widget.theme == SFCalendarTheme.light
+                            ? SFColor.grayScale80
+                            : Colors.white),
+                    size: widget.contentSize + 2,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ...List.generate(
+                7,
+                (index) => Expanded(
+                  child: Text(
+                    weekNames[index],
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      fontFamily: 'PretendardMedium',
+                      fontSize: widget.contentSize,
+                      color: index == 0
+                          ? Colors.red
+                          : index == 6
+                              ? SFColor.primary100
+                              : widget.textColor ??
+                                  (widget.theme == SFCalendarTheme.light
+                                      ? SFColor.grayScale80
+                                      : Colors.white),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: widget.verticalSpacing),
+          Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              ...List.generate(
+                6,
+                (index1) => Padding(
+                  padding: EdgeInsets.only(bottom: widget.verticalSpacing),
+                  child: Row(
+                    children: [
+                      ...List.generate(
+                        7,
+                        (index2) => Expanded(
+                          child: GestureDetector(
+                            onTap: _calender[index1 * 7 + index2].month !=
+                                    _viewMonth.month
+                                ? () {
+                                    _viewMonth = DateTime(
+                                        _calender[index1 * 7 + index2].year,
+                                        _calender[index1 * 7 + index2].month);
+                                    selectedDate(index1, index2);
+                                    viewCalender();
+                                    _isSelected = true;
+                                    setState(() {});
+                                  }
+                                : () {
+                                    _isSelected = true;
+                                    selectedDate(index1, index2);
+                                    setState(() {});
+                                  },
+                            child: Container(
+                              decoration: BoxDecoration(
+                                color: isRange(index1, index2)
+                                    ? widget.rangeColor
+                                    : null,
+                                gradient: _rangeGradient(
+                                    _calender[index1 * 7 + index2]),
+                              ),
+                              child: Container(
+                                padding: EdgeInsets.symmetric(
+                                  horizontal: widget.horizontalSpacing / 2,
+                                  vertical: widget.verticalSpacing / 2,
+                                ),
+                                decoration: BoxDecoration(
+                                  shape: BoxShape.circle,
+                                  color: _dayBoxColor(
+                                      _calender[index1 * 7 + index2]),
+                                ),
+                                child: Padding(
+                                  padding: const EdgeInsets.all(2),
+                                  child: Text(
+                                    _calender[index1 * 7 + index2]
+                                        .day
+                                        .toString(),
+                                    textAlign: TextAlign.center,
+                                    style: TextStyle(
+                                      fontFamily: 'PretendardMedium',
+                                      fontSize: widget.contentSize,
+                                      color: dayTextColor(
+                                        _calender[index1 * 7 + index2],
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+
+  Color _dayBoxColor(DateTime date) {
+    if (_isSelected) {
+      switch (widget.status) {
+        case SFCalendarStatus.list:
+          return _selectedDateList.indexWhere((e) =>
+                      e.year == date.year &&
+                      e.month == date.month &&
+                      e.day == date.day) !=
+                  -1
+              ? widget.selectedColor
+              : Colors.transparent;
+        case SFCalendarStatus.range:
+          return ((_selectRangeStart?.year == date.year &&
+                      _selectRangeStart?.month == date.month &&
+                      _selectRangeStart?.day == date.day) ||
+                  (_selectRangeEnd?.year == date.year &&
+                      _selectRangeEnd?.month == date.month &&
+                      _selectRangeEnd?.day == date.day))
+              ? widget.selectedColor
+              : Colors.transparent;
+        case SFCalendarStatus.one:
+          return (_selectOne != null &&
+                  _selectOne!.year == date.year &&
+                  _selectOne!.month == date.month &&
+                  _selectOne!.day == date.day)
+              ? widget.selectedColor
+              : Colors.transparent;
+      }
+    } else {
+      return (date.year == DateTime.now().year &&
+              date.month == DateTime.now().month &&
+              date.day == DateTime.now().day)
+          ? widget.selectedColor
+          : Colors.transparent;
+    }
+  }
+
+  Color dayTextColor(DateTime date) {
+    int overStart = 0;
+    int underEnd = 0;
+    if (widget.status == SFCalendarStatus.range &&
+        _selectRangeStart != null &&
+        _selectRangeStart != null) {
+      overStart = _selectRangeStart?.compareTo(date) ?? 0;
+      underEnd = _selectRangeEnd?.compareTo(date) ?? 0;
+    }
+    if (_isSelected) {
+      switch (widget.status) {
+        case SFCalendarStatus.list:
+          return _selectedDateList.indexWhere((e) =>
+                      e.year == date.year &&
+                      e.month == date.month &&
+                      e.day == date.day) !=
+                  -1
+              ? _selectedTextColor
+              : date.month != _viewMonth.month
+                  ? SFColor.grayScale30
+                  : date.weekday == 6
+                      ? SFColor.primary100
+                      : date.weekday == 7
+                          ? SFColor.red
+                          : widget.textColor ??
+                              (widget.theme == SFCalendarTheme.light
+                                  ? SFColor.grayScale80
+                                  : Colors.white);
+        case SFCalendarStatus.range:
+          return ((_selectRangeStart?.year == date.year &&
+                      _selectRangeStart?.month == date.month &&
+                      _selectRangeStart?.day == date.day) ||
+                  (_selectRangeEnd?.year == date.year &&
+                      _selectRangeEnd?.month == date.month &&
+                      _selectRangeEnd?.day == date.day) ||
+                  (overStart < 0 && underEnd > 0))
+              ? _selectedTextColor
+              : date.month != _viewMonth.month
+                  ? SFColor.grayScale30
+                  : date.weekday == 6
+                      ? SFColor.primary100
+                      : date.weekday == 7
+                          ? SFColor.red
+                          : widget.textColor ??
+                              (widget.theme == SFCalendarTheme.light
+                                  ? SFColor.grayScale80
+                                  : Colors.white);
+        case SFCalendarStatus.one:
+          return (_selectOne != null &&
+                  _selectOne!.year == date.year &&
+                  _selectOne!.month == date.month &&
+                  _selectOne!.day == date.day)
+              ? _selectedTextColor
+              : date.month != _viewMonth.month
+                  ? SFColor.grayScale30
+                  : date.weekday == 6
+                      ? SFColor.primary100
+                      : date.weekday == 7
+                          ? SFColor.red
+                          : widget.textColor ??
+                              (widget.theme == SFCalendarTheme.light
+                                  ? SFColor.grayScale80
+                                  : Colors.white);
+      }
+    } else {
+      return (date.year == DateTime.now().year &&
+              date.month == DateTime.now().month &&
+              date.day == DateTime.now().day)
+          ? _selectedTextColor
+          : date.month != _viewMonth.month
+              ? SFColor.grayScale30
+              : date.weekday == 6
+                  ? SFColor.primary100
+                  : date.weekday == 7
+                      ? SFColor.red
+                      : widget.textColor ??
+                          (widget.theme == SFCalendarTheme.light
+                              ? SFColor.grayScale80
+                              : Colors.white);
+    }
+  }
+
+  LinearGradient? _rangeGradient(DateTime date) {
+    if (_selectRangeStart != null && _selectRangeEnd != null) {
+      if (_selectRangeStart?.year == date.year &&
+          _selectRangeStart?.month == date.month &&
+          _selectRangeStart?.day == date.day) {
+        return LinearGradient(
+          tileMode: TileMode.clamp,
+          colors: [
+            Colors.transparent,
+            widget.rangeColor,
+          ],
+          stops: const [.4, .5],
+        );
+      } else if (_selectRangeEnd?.year == date.year &&
+          _selectRangeEnd?.month == date.month &&
+          _selectRangeEnd?.day == date.day) {
+        return LinearGradient(
+          tileMode: TileMode.clamp,
+          colors: [
+            widget.rangeColor,
+            Colors.transparent,
+          ],
+          stops: const [.4, .5],
+        );
+      }
+    } else {
+      return null;
+    }
+    return null;
+  }
+}

--- a/lib/widgets/datepicker/calendar.dart
+++ b/lib/widgets/datepicker/calendar.dart
@@ -544,7 +544,7 @@ class _DatePickerWidgetState extends State<SFCalendar> {
             Colors.transparent,
             widget.rangeColor,
           ],
-          stops: const [.4, .5],
+          stops: const [.5, .5],
         );
       } else if (_selectRangeEnd?.year == date.year &&
           _selectRangeEnd?.month == date.month &&
@@ -555,7 +555,7 @@ class _DatePickerWidgetState extends State<SFCalendar> {
             widget.rangeColor,
             Colors.transparent,
           ],
-          stops: const [.4, .5],
+          stops: const [.5, .5],
         );
       }
     } else {

--- a/lib/widgets/datepicker/calendar.dart
+++ b/lib/widgets/datepicker/calendar.dart
@@ -33,24 +33,64 @@ class SFCalendar extends StatefulWidget {
   })  : assert(
             verticalSpacing >= 0 && horizontalSpacing >= 0 && contentSize > 0),
         super(key: key);
+  // 캘린터 status
+  // list 선택한 날짜 리스트
+  // range 선택한 기간
+  // one 선택한 날짜 하나
   final SFCalendarStatus status;
+
+  // 캘린터 테마 dart, light
   final SFCalendarTheme theme;
+
+  // 초기 선택한 날짜 리스트
   final List<DateTime>? initialDateList;
+
+  // 초기 선택한 기간
   final DateTimeRange? initialDateRange;
+
+  // 초기 선택한 날짜
   final DateTime? initialDateOne;
+
+  // 캘린더 배경색
   final Color? backgroundColor;
+
+  // 캘린터 텍스트 컬러
   final Color? textColor;
+
+  // 선택한 날짜 배경색
   final Color selectedColor;
+
+  // 선택한 기간 배경색
   final Color rangeColor;
+
+  // 선택한 날짜 텍스트 색
   final Color? selectedTextColor;
+
+  // 캘린터 테두리 곡선
   final BorderRadius borderRadius;
+
+  // 캘린더 내용 사이즈 날짜, 요일, 년도, 아이콘 크기 등 비율은 고정되어있다
   final double contentSize;
+
+  // vertical 간격
   final double verticalSpacing;
+
+  // horizontal 간격
   final double horizontalSpacing;
+
+  // 가로 너비
   final double? width;
+
+  // 높이
   final double? height;
+
+  // 캘린더 padding
   final EdgeInsetsGeometry? padding;
+
+  // 선택한 list, range(start, end), one 를 받을 수 있다.
   final GetSelectedDate? getSelectedDate;
+
+  // 초기 오늘 날짜 마크를 할 것인지
   final bool todayMark;
 
   @override

--- a/lib/widgets/datepicker/calendar.dart
+++ b/lib/widgets/datepicker/calendar.dart
@@ -4,14 +4,14 @@ import 'package:sfac_design_flutter/sfac_design_flutter.dart';
 typedef GetSelectedDate = void Function(DateTime? start, DateTime? end,
     List<DateTime>? selectedDateList, DateTime? selectedOne);
 
-enum SFCalendarStatus { list, range, one }
+enum SFCalendarType { list, range, one }
 
 enum SFCalendarTheme { light, dark }
 
 class SFCalendar extends StatefulWidget {
   const SFCalendar({
     Key? key,
-    this.type = SFCalendarStatus.one,
+    this.type = SFCalendarType.one,
     this.theme = SFCalendarTheme.light,
     this.initialDateList,
     this.initialDateRange,
@@ -36,7 +36,7 @@ class SFCalendar extends StatefulWidget {
   // list 선택한 날짜 리스트
   // range 선택한 기간
   // one 선택한 날짜 하나
-  final SFCalendarStatus type;
+  final SFCalendarType type;
 
   // 캘린터 테마 dart, light
   final SFCalendarTheme theme;
@@ -112,15 +112,15 @@ class _DatePickerWidgetState extends State<SFCalendar> {
   void initState() {
     super.initState();
     switch (widget.type) {
-      case SFCalendarStatus.list:
+      case SFCalendarType.list:
         _selectedDateList.addAll(widget.initialDateList ?? []);
         break;
-      case SFCalendarStatus.range:
+      case SFCalendarType.range:
         _selectRangeStart = widget.initialDateRange?.start;
         _selectRangeEnd = widget.initialDateRange?.end;
 
         break;
-      case SFCalendarStatus.one:
+      case SFCalendarType.one:
         _selectOne = widget.initialDateOne;
         break;
     }
@@ -197,7 +197,7 @@ class _DatePickerWidgetState extends State<SFCalendar> {
   }
 
   bool isRange(int index1, int index2) {
-    return widget.type == SFCalendarStatus.range &&
+    return widget.type == SFCalendarType.range &&
         _selectRangeStart != null &&
         _selectRangeEnd != null &&
         (_selectRangeStart!.isBefore(_calender[index1 * 7 + index2]) &&
@@ -209,20 +209,20 @@ class _DatePickerWidgetState extends State<SFCalendar> {
 
   selectedDate(int index1, int index2) {
     switch (widget.type) {
-      case SFCalendarStatus.list:
+      case SFCalendarType.list:
         selectDate(_calender[index1 * 7 + index2]);
         if (widget.getSelectedDate != null) {
           widget.getSelectedDate!(null, null, _selectedDateList, null);
         }
         break;
-      case SFCalendarStatus.range:
+      case SFCalendarType.range:
         selectDateRange(_calender[index1 * 7 + index2]);
         if (widget.getSelectedDate != null) {
           widget.getSelectedDate!(
               _selectRangeStart, _selectRangeEnd, null, null);
         }
         break;
-      case SFCalendarStatus.one:
+      case SFCalendarType.one:
         selectedOne(_calender[index1 * 7 + index2]);
         if (widget.getSelectedDate != null) {
           widget.getSelectedDate!(null, null, null, _selectOne);
@@ -417,7 +417,7 @@ class _DatePickerWidgetState extends State<SFCalendar> {
   Color _dayBoxColor(DateTime date) {
     if (_isSelected) {
       switch (widget.type) {
-        case SFCalendarStatus.list:
+        case SFCalendarType.list:
           return _selectedDateList.indexWhere((e) =>
                       e.year == date.year &&
                       e.month == date.month &&
@@ -425,7 +425,7 @@ class _DatePickerWidgetState extends State<SFCalendar> {
                   -1
               ? widget.selectedColor
               : Colors.transparent;
-        case SFCalendarStatus.range:
+        case SFCalendarType.range:
           return ((_selectRangeStart?.year == date.year &&
                       _selectRangeStart?.month == date.month &&
                       _selectRangeStart?.day == date.day) ||
@@ -434,7 +434,7 @@ class _DatePickerWidgetState extends State<SFCalendar> {
                       _selectRangeEnd?.day == date.day))
               ? widget.selectedColor
               : Colors.transparent;
-        case SFCalendarStatus.one:
+        case SFCalendarType.one:
           return (_selectOne != null &&
                   _selectOne!.year == date.year &&
                   _selectOne!.month == date.month &&
@@ -454,7 +454,7 @@ class _DatePickerWidgetState extends State<SFCalendar> {
   Color dayTextColor(DateTime date) {
     int overStart = 0;
     int underEnd = 0;
-    if (widget.type == SFCalendarStatus.range &&
+    if (widget.type == SFCalendarType.range &&
         _selectRangeStart != null &&
         _selectRangeStart != null) {
       overStart = _selectRangeStart?.compareTo(date) ?? 0;
@@ -462,7 +462,7 @@ class _DatePickerWidgetState extends State<SFCalendar> {
     }
     if (_isSelected) {
       switch (widget.type) {
-        case SFCalendarStatus.list:
+        case SFCalendarType.list:
           return _selectedDateList.indexWhere((e) =>
                       e.year == date.year &&
                       e.month == date.month &&
@@ -479,7 +479,7 @@ class _DatePickerWidgetState extends State<SFCalendar> {
                               (widget.theme == SFCalendarTheme.light
                                   ? SFColor.grayScale80
                                   : Colors.white);
-        case SFCalendarStatus.range:
+        case SFCalendarType.range:
           return ((_selectRangeStart?.year == date.year &&
                       _selectRangeStart?.month == date.month &&
                       _selectRangeStart?.day == date.day) ||
@@ -498,7 +498,7 @@ class _DatePickerWidgetState extends State<SFCalendar> {
                               (widget.theme == SFCalendarTheme.light
                                   ? SFColor.grayScale80
                                   : Colors.white);
-        case SFCalendarStatus.one:
+        case SFCalendarType.one:
           return (_selectOne != null &&
                   _selectOne!.year == date.year &&
                   _selectOne!.month == date.month &&

--- a/lib/widgets/datepicker/calendar.dart
+++ b/lib/widgets/datepicker/calendar.dart
@@ -26,7 +26,6 @@ class SFCalendar extends StatefulWidget {
     this.verticalSpacing = 12,
     this.horizontalSpacing = 12,
     this.width,
-    this.height,
     this.padding,
     this.getSelectedDate,
     this.todayMark = true,
@@ -80,9 +79,6 @@ class SFCalendar extends StatefulWidget {
 
   // 가로 너비
   final double? width;
-
-  // 높이
-  final double? height;
 
   // 캘린더 padding
   final EdgeInsetsGeometry? padding;
@@ -239,7 +235,6 @@ class _DatePickerWidgetState extends State<SFCalendar> {
   Widget build(BuildContext context) {
     return Container(
       width: widget.width,
-      height: widget.height,
       padding: widget.padding ??
           const EdgeInsets.symmetric(
             vertical: 20,
@@ -277,15 +272,19 @@ class _DatePickerWidgetState extends State<SFCalendar> {
                   ),
                 ),
               ),
-              Text(
-                '${_viewMonth.year}년 ${_viewMonth.month}월',
-                style: TextStyle(
-                  fontFamily: 'PretendardBold',
-                  fontSize: widget.contentSize + 4,
-                  color: widget.textColor ??
-                      (widget.theme == SFCalendarTheme.light
-                          ? SFColor.grayScale80
-                          : Colors.white),
+              Expanded(
+                child: Center(
+                  child: Text(
+                    '${_viewMonth.year}년 ${_viewMonth.month}월',
+                    style: TextStyle(
+                      fontFamily: 'PretendardBold',
+                      fontSize: widget.contentSize + 4,
+                      color: widget.textColor ??
+                          (widget.theme == SFCalendarTheme.light
+                              ? SFColor.grayScale80
+                              : Colors.white),
+                    ),
+                  ),
                 ),
               ),
               GestureDetector(

--- a/lib/widgets/datepicker/date_picker.dart
+++ b/lib/widgets/datepicker/date_picker.dart
@@ -31,7 +31,6 @@ class SFDatePicker extends StatefulWidget {
     this.todayMark = true,
     this.width,
     this.calendarWidth,
-    this.calendarHeight,
   })  : assert(
             verticalSpacing >= 0 && horizontalSpacing >= 0 && contentSize > 0),
         super(key: key);
@@ -112,9 +111,6 @@ class SFDatePicker extends StatefulWidget {
   // 캘린터 가로 너비
   final double? calendarWidth;
 
-  // 캘린더 높이
-  final double? calendarHeight;
-
   @override
   State<SFDatePicker> createState() => _SFDatePickerState();
 }
@@ -146,14 +142,14 @@ class _SFDatePickerState extends State<SFDatePicker> {
             ),
           ),
           Positioned(
-            width: widget.calendarWidth,
+            width: widget.calendarWidth ?? size!.width,
             child: CompositedTransformFollower(
               link: _layerLink,
               offset: Offset(0, size!.height),
               child: Material(
                 color: Colors.transparent,
                 child: Container(
-                    width: widget.calendarWidth,
+                    width: widget.calendarWidth ?? size!.width,
                     decoration: BoxDecoration(
                       color: widget.backgroundColor ?? Colors.white,
                       borderRadius: widget.borderRadius,
@@ -182,8 +178,7 @@ class _SFDatePickerState extends State<SFDatePicker> {
                       contentSize: widget.contentSize,
                       verticalSpacing: widget.verticalSpacing,
                       horizontalSpacing: widget.horizontalSpacing,
-                      width: widget.calendarWidth,
-                      height: widget.calendarHeight,
+                      width: widget.calendarWidth ?? size!.width,
                       padding: widget.padding,
                       getSelectedDate:
                           (start, end, selectedDateList, selectedOne) {

--- a/lib/widgets/datepicker/date_picker.dart
+++ b/lib/widgets/datepicker/date_picker.dart
@@ -180,6 +180,7 @@ class _SFDatePickerState extends State<SFDatePicker> {
                       horizontalSpacing: widget.horizontalSpacing,
                       width: widget.calendarWidth ?? size!.width,
                       padding: widget.padding,
+                      todayMark: widget.todayMark,
                       getSelectedDate:
                           (start, end, selectedDateList, selectedOne) {
                         if (widget.getSelectedDate != null) {

--- a/lib/widgets/datepicker/date_picker.dart
+++ b/lib/widgets/datepicker/date_picker.dart
@@ -1,0 +1,314 @@
+import 'package:flutter/material.dart';
+import 'package:sfac_design_flutter/sfac_design_flutter.dart';
+import 'package:sfac_design_flutter/widgets/datepicker/calendar.dart';
+
+
+class SFDatePicker extends StatefulWidget {
+  const SFDatePicker({
+    Key? key,
+    this.text,
+    this.textStyle,
+    this.selectTextStyle,
+    this.suffixIcon,
+    this.status = SFCalendarStatus.range,
+    this.theme = SFCalendarTheme.light,
+    this.initialDateList,
+    this.initialDateRange,
+    this.initialDateOne,
+    this.backgroundColor,
+    this.textColor,
+    this.selectedColor = SFColor.primary100,
+    this.rangeColor = SFColor.primary100,
+    this.selectedTextColor,
+    this.borderRadius = const BorderRadius.all(Radius.circular(10)),
+    this.contentSize = 16,
+    this.verticalSpacing = 12,
+    this.horizontalSpacing = 12,
+    this.padding,
+    this.getSelectedDate,
+    this.outlineColor,
+    this.outlineWidth = 1,
+    this.todayMark = true,
+    this.width,
+    this.calendarWidth,
+    this.calendarHeight,
+  })  : assert(
+            verticalSpacing >= 0 && horizontalSpacing >= 0 && contentSize > 0),
+        super(key: key);
+  final String? text;
+  final TextStyle? textStyle;
+  final TextStyle? selectTextStyle;
+  final Icon? suffixIcon;
+  final SFCalendarStatus status;
+  final SFCalendarTheme theme;
+  final List<DateTime>? initialDateList;
+  final DateTimeRange? initialDateRange;
+  final DateTime? initialDateOne;
+  final Color? backgroundColor;
+  final Color? textColor;
+  final Color selectedColor;
+  final Color rangeColor;
+  final Color? selectedTextColor;
+  final BorderRadius borderRadius;
+  final double contentSize;
+  final double verticalSpacing;
+  final double horizontalSpacing;
+  final EdgeInsetsGeometry? padding;
+  final GetSelectedDate? getSelectedDate;
+  final Color? outlineColor;
+  final double outlineWidth;
+  final bool todayMark;
+  final double? width;
+  final double? calendarWidth;
+  final double? calendarHeight;
+
+  @override
+  State<SFDatePicker> createState() => _SFDatePickerState();
+}
+
+class _SFDatePickerState extends State<SFDatePicker> {
+  String? _selectDate;
+  OverlayEntry? _overlayEntry;
+  final LayerLink _layerLink = LayerLink();
+  final GlobalKey _buttonKey = GlobalKey();
+  Size? size;
+  final List<DateTime> _selectedDateList = [];
+  DateTime? _selectRangeStart;
+  DateTime? _selectRangeEnd;
+  DateTime? _selectOne;
+
+  void createOverlayEntry() {
+    _overlayEntry = OverlayEntry(
+      builder: (context) => Stack(
+        children: [
+          GestureDetector(
+            onTap: () {
+              hideDropdown();
+              FocusScope.of(context).unfocus();
+            },
+            child: Container(
+              color: Colors.transparent,
+              width: double.infinity,
+              height: double.infinity,
+            ),
+          ),
+          Positioned(
+            width: widget.calendarWidth,
+            child: CompositedTransformFollower(
+              link: _layerLink,
+              offset: Offset(0, size!.height),
+              child: Material(
+                color: Colors.transparent,
+                child: Container(
+                    width: widget.calendarWidth,
+                    decoration: BoxDecoration(
+                      color: widget.backgroundColor ?? Colors.white,
+                      borderRadius: widget.borderRadius,
+                      border: Border.all(
+                        color: widget.outlineColor ?? SFColor.grayScale20,
+                        width: widget.outlineWidth,
+                      ),
+                    ),
+                    child: SFCalendar(
+                      status: widget.status,
+                      theme: widget.theme,
+                      initialDateList: _selectedDateList,
+                      initialDateRange:
+                          _selectRangeStart != null && _selectRangeEnd != null
+                              ? DateTimeRange(
+                                  start: _selectRangeStart!,
+                                  end: _selectRangeEnd!)
+                              : null,
+                      initialDateOne: _selectOne,
+                      backgroundColor: widget.backgroundColor,
+                      textColor: widget.textColor,
+                      selectedColor: widget.selectedColor,
+                      rangeColor: widget.rangeColor,
+                      selectedTextColor: widget.selectedTextColor,
+                      borderRadius: widget.borderRadius,
+                      contentSize: widget.contentSize,
+                      verticalSpacing: widget.verticalSpacing,
+                      horizontalSpacing: widget.horizontalSpacing,
+                      width: widget.calendarWidth,
+                      height: widget.calendarHeight,
+                      padding: widget.padding,
+                      getSelectedDate:
+                          (start, end, selectedDateList, selectedOne) {
+                        if (widget.getSelectedDate != null) {
+                          widget.getSelectedDate!(
+                              start, end, selectedDateList, selectedOne);
+                        }
+                        String month;
+                        String day;
+                        switch (widget.status) {
+                          case SFCalendarStatus.list:
+                            List<String> dateList = [];
+                            if (selectedDateList != null &&
+                                selectedDateList.isNotEmpty) {
+                              _selectedDateList.clear();
+                              _selectedDateList.addAll(selectedDateList);
+                              _selectedDateList.sort();
+                              for (var date in _selectedDateList) {
+                                month = date.month.toString().padLeft(2, '0');
+                                day = date.day.toString().padLeft(2, '0');
+                                dateList.add('${date.year}.$month.$day');
+                              }
+                              _selectDate = dateList.join(', ').toString();
+                            } else {
+                              dateList.clear();
+                              _selectDate = null;
+                            }
+                            break;
+                          case SFCalendarStatus.range:
+                            if (start != null && end != null) {
+                              _selectRangeStart = start;
+                              _selectRangeEnd = end;
+                              month = start.month.toString().padLeft(2, '0');
+                              day = start.day.toString().padLeft(2, '0');
+                              var endMonth =
+                                  end.month.toString().padLeft(2, '0');
+                              var endDay = end.day.toString().padLeft(2, '0');
+                              _selectDate =
+                                  '${start.year}.$month.$day ~ ${end.year}.$endMonth.$endDay';
+                            } else {
+                              _selectRangeStart = null;
+                              _selectRangeEnd = null;
+                              _selectDate = null;
+                            }
+                            break;
+                          case SFCalendarStatus.one:
+                            if (selectedOne != null) {
+                              _selectOne = selectedOne;
+                              month =
+                                  selectedOne.month.toString().padLeft(2, '0');
+                              day = selectedOne.day.toString().padLeft(2, '0');
+                              _selectDate = '${selectedOne.year}.$month.$day';
+                            } else {
+                              _selectOne = null;
+                              _selectDate = null;
+                            }
+                            break;
+                        }
+                        setState(() {});
+                      },
+                    )),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void showDropdown() {
+    _overlayEntry = null;
+    createOverlayEntry();
+    Overlay.of(context, rootOverlay: true).insert(_overlayEntry!);
+  }
+
+  void hideDropdown() {
+    _overlayEntry?.remove();
+    _overlayEntry = null;
+  }
+
+  void toggleDropdown() {
+    if (_overlayEntry == null) {
+      showDropdown();
+    } else {
+      hideDropdown();
+    }
+  }
+
+  Size? _getSize() {
+    if (_buttonKey.currentContext != null) {
+      final RenderBox renderBox =
+          _buttonKey.currentContext!.findRenderObject() as RenderBox;
+      Size size = renderBox.size;
+      return size;
+    }
+    return null;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      setState(() {
+        size = _getSize();
+      });
+    });
+    switch (widget.status) {
+      case SFCalendarStatus.list:
+        _selectedDateList.addAll(widget.initialDateList ?? []);
+        break;
+      case SFCalendarStatus.range:
+        _selectRangeStart = widget.initialDateRange?.start;
+        _selectRangeEnd = widget.initialDateRange?.end;
+
+        break;
+      case SFCalendarStatus.one:
+        _selectOne = widget.initialDateOne;
+        break;
+    }
+  }
+
+  void popOverlay() {
+    if (_overlayEntry != null) {
+      hideDropdown();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: () async {
+        popOverlay();
+        return true;
+      },
+      child: CompositedTransformTarget(
+        link: _layerLink,
+        child: GestureDetector(
+          key: _buttonKey,
+          onTap: toggleDropdown,
+          child: Container(
+            width: widget.width,
+            padding: const EdgeInsets.all(6),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: widget.borderRadius,
+              border: Border.all(
+                color: widget.outlineColor ?? SFColor.grayScale20,
+                width: widget.outlineWidth,
+              ),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  child: Text(
+                    _selectDate ?? widget.text ?? 'Pick a date',
+                    overflow: TextOverflow.ellipsis,
+                    maxLines: 1,
+                    style: widget.textStyle ??
+                        SFTextStyle.b4B14(
+                            color: _selectDate != null
+                                ? SFColor.grayScale80
+                                : SFColor.grayScale30),
+                  ),
+                ),
+                widget.suffixIcon ??
+                    Transform.rotate(
+                        angle: 90 * 3.1415926535 / 180,
+                        child: widget.suffixIcon ??
+                            const Icon(
+                              Icons.play_arrow,
+                              color: SFColor.grayScale40,
+                            ))
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/datepicker/date_picker.dart
+++ b/lib/widgets/datepicker/date_picker.dart
@@ -10,7 +10,7 @@ class SFDatePicker extends StatefulWidget {
     this.textStyle,
     this.selectTextStyle,
     this.suffixIcon,
-    this.type = SFCalendarStatus.one,
+    this.type = SFCalendarType.one,
     this.theme = SFCalendarTheme.light,
     this.initialDateList,
     this.initialDateRange,
@@ -49,7 +49,7 @@ class SFDatePicker extends StatefulWidget {
   // 캘린터 status
   // list 선택한 날짜 리스트
   // range 선택한 기간
-  final SFCalendarStatus type;
+  final SFCalendarType type;
 
   // 캘린터 테마 dart, light
   final SFCalendarTheme theme;
@@ -190,7 +190,7 @@ class _SFDatePickerState extends State<SFDatePicker> {
                         String month;
                         String day;
                         switch (widget.type) {
-                          case SFCalendarStatus.list:
+                          case SFCalendarType.list:
                             List<String> dateList = [];
                             if (selectedDateList != null &&
                                 selectedDateList.isNotEmpty) {
@@ -208,7 +208,7 @@ class _SFDatePickerState extends State<SFDatePicker> {
                               _selectDate = null;
                             }
                             break;
-                          case SFCalendarStatus.range:
+                          case SFCalendarType.range:
                             if (start != null && end != null) {
                               _selectRangeStart = start;
                               _selectRangeEnd = end;
@@ -225,7 +225,7 @@ class _SFDatePickerState extends State<SFDatePicker> {
                               _selectDate = null;
                             }
                             break;
-                          case SFCalendarStatus.one:
+                          case SFCalendarType.one:
                             if (selectedOne != null) {
                               _selectOne = selectedOne;
                               month =
@@ -287,15 +287,15 @@ class _SFDatePickerState extends State<SFDatePicker> {
       });
     });
     switch (widget.type) {
-      case SFCalendarStatus.list:
+      case SFCalendarType.list:
         _selectedDateList.addAll(widget.initialDateList ?? []);
         break;
-      case SFCalendarStatus.range:
+      case SFCalendarType.range:
         _selectRangeStart = widget.initialDateRange?.start;
         _selectRangeEnd = widget.initialDateRange?.end;
 
         break;
-      case SFCalendarStatus.one:
+      case SFCalendarType.one:
         _selectOne = widget.initialDateOne;
         break;
     }

--- a/lib/widgets/datepicker/date_picker.dart
+++ b/lib/widgets/datepicker/date_picker.dart
@@ -10,7 +10,7 @@ class SFDatePicker extends StatefulWidget {
     this.textStyle,
     this.selectTextStyle,
     this.suffixIcon,
-    this.status = SFCalendarStatus.range,
+    this.type = SFCalendarStatus.one,
     this.theme = SFCalendarTheme.light,
     this.initialDateList,
     this.initialDateRange,
@@ -49,7 +49,7 @@ class SFDatePicker extends StatefulWidget {
   // 캘린터 status
   // list 선택한 날짜 리스트
   // range 선택한 기간
-  final SFCalendarStatus status;
+  final SFCalendarStatus type;
 
   // 캘린터 테마 dart, light
   final SFCalendarTheme theme;
@@ -159,7 +159,7 @@ class _SFDatePickerState extends State<SFDatePicker> {
                       ),
                     ),
                     child: SFCalendar(
-                      status: widget.status,
+                      type: widget.type,
                       theme: widget.theme,
                       initialDateList: _selectedDateList,
                       initialDateRange:
@@ -188,7 +188,7 @@ class _SFDatePickerState extends State<SFDatePicker> {
                         }
                         String month;
                         String day;
-                        switch (widget.status) {
+                        switch (widget.type) {
                           case SFCalendarStatus.list:
                             List<String> dateList = [];
                             if (selectedDateList != null &&
@@ -285,7 +285,7 @@ class _SFDatePickerState extends State<SFDatePicker> {
         size = _getSize();
       });
     });
-    switch (widget.status) {
+    switch (widget.type) {
       case SFCalendarStatus.list:
         _selectedDateList.addAll(widget.initialDateList ?? []);
         break;

--- a/lib/widgets/datepicker/date_picker.dart
+++ b/lib/widgets/datepicker/date_picker.dart
@@ -8,7 +8,6 @@ class SFDatePicker extends StatefulWidget {
     Key? key,
     this.text,
     this.textStyle,
-    this.selectTextStyle,
     this.suffixIcon,
     this.type = SFCalendarType.one,
     this.theme = SFCalendarTheme.light,
@@ -16,7 +15,7 @@ class SFDatePicker extends StatefulWidget {
     this.initialDateRange,
     this.initialDateOne,
     this.backgroundColor,
-    this.textColor,
+    this.calendarTextColor,
     this.selectedColor = SFColor.primary100,
     this.rangeColor = SFColor.primary100,
     this.selectedTextColor,
@@ -39,9 +38,6 @@ class SFDatePicker extends StatefulWidget {
 
   // 드롭박스 TextStyle 
   final TextStyle? textStyle;
-
-  // 캘린더 선택한 날짜 TextStyle
-  final TextStyle? selectTextStyle;
 
   // 드롭박스 suffixIcon
   final Widget? suffixIcon;
@@ -67,7 +63,7 @@ class SFDatePicker extends StatefulWidget {
   final Color? backgroundColor;
 
   // 캘린터 텍스트 컬러
-  final Color? textColor;
+  final Color? calendarTextColor;
 
   // 선택한 날짜 배경색
   final Color selectedColor;
@@ -170,7 +166,7 @@ class _SFDatePickerState extends State<SFDatePicker> {
                               : null,
                       initialDateOne: _selectOne,
                       backgroundColor: widget.backgroundColor,
-                      textColor: widget.textColor,
+                      textColor: widget.calendarTextColor,
                       selectedColor: widget.selectedColor,
                       rangeColor: widget.rangeColor,
                       selectedTextColor: widget.selectedTextColor,

--- a/lib/widgets/datepicker/date_picker.dart
+++ b/lib/widgets/datepicker/date_picker.dart
@@ -35,31 +35,84 @@ class SFDatePicker extends StatefulWidget {
   })  : assert(
             verticalSpacing >= 0 && horizontalSpacing >= 0 && contentSize > 0),
         super(key: key);
+  // 드롭박스 text
   final String? text;
+
+  // 드롭박스 TextStyle 
   final TextStyle? textStyle;
+
+  // 캘린더 선택한 날짜 TextStyle
   final TextStyle? selectTextStyle;
-  final Icon? suffixIcon;
+
+  // 드롭박스 suffixIcon
+  final Widget? suffixIcon;
+
+  // 캘린터 status
+  // list 선택한 날짜 리스트
+  // range 선택한 기간
   final SFCalendarStatus status;
+
+  // 캘린터 테마 dart, light
   final SFCalendarTheme theme;
+
+  // 초기 선택한 날짜 리스트
   final List<DateTime>? initialDateList;
+
+  // 초기 선택한 기간
   final DateTimeRange? initialDateRange;
+
+  // 초기 선택한 날짜
   final DateTime? initialDateOne;
+
+  // 캘린더 배경색
   final Color? backgroundColor;
+
+  // 캘린터 텍스트 컬러
   final Color? textColor;
+
+  // 선택한 날짜 배경색
   final Color selectedColor;
+
+  // 선택한 기간 배경색
   final Color rangeColor;
+
+  // 선택한 날짜 텍스트 색
   final Color? selectedTextColor;
+
+  // 캘린터 테두리 곡선
   final BorderRadius borderRadius;
+
+  // 캘린더 내용 사이즈 날짜, 요일, 년도, 아이콘 크기 등 비율은 고정되어있다
   final double contentSize;
+
+  // vertical 간격
   final double verticalSpacing;
+
+  // horizontal 간격
   final double horizontalSpacing;
+
+  // 캘린더 padding
   final EdgeInsetsGeometry? padding;
+
+  // 선택한 list, range(start, end), one 를 받을 수 있다.
   final GetSelectedDate? getSelectedDate;
+
+  // 드롭박스 테두리 색
   final Color? outlineColor;
+
+  // 드롭박스 테두리 굵기
   final double outlineWidth;
+
+  // 캘린터 초기 오늘 날짜 마크를 할 것인지
   final bool todayMark;
+
+  // 드롭박스 가로 너비
   final double? width;
+
+  // 캘린터 가로 너비
   final double? calendarWidth;
+
+  // 캘린더 높이
   final double? calendarHeight;
 
   @override


### PR DESCRIPTION
## 요약 및 목적
**Calendar**
달력 기능
**DatePicker**
달력 기능 + 드롭 박스

`SFCalendarStatus.list`:  선택한 날짜 리스트
`SFCalendarStatus.range`: 선택한 기간
`SFCalendarStatus.one`: 선택한 날짜

`getSelectedDate` 속성를 통해 선택한 list, range(start, end), one 값을 받을 수 있다.
`getSelectedDate: (start, end, selectedDateList, selectedOne) {}`


## 변경사항에 대한 자세한 설명
**[d5b301a](https://github.com/sniperfactory-official/sfac-designkit-flutter/pull/96/commits/d5b301a133d22f1eeb6cda0bb0fe056d60c1a77c)**
`calendar`: height 속성 삭제 및 년도 Text 위젯 Expanded, Center 설정
`datePicker`: `calendarHeight` 삭제, `calendarWidth` 기본 값 드롭박스의 `width` 값으로 설정

**[ae59cfd](https://github.com/sniperfactory-official/sfac-designkit-flutter/pull/96/commits/ae59cfd75a53e0b3febedefe1834958cc15f043a)**
속성 명 `status` -> `type` 변경
`type` 기본 값 `range` -> `one` 변경

**[dc0e670](https://github.com/sniperfactory-official/sfac-designkit-flutter/pull/96/commits/dc0e670e5d17fbd55ffd3ddf3c06b50b27865c2d)**
`datePicker`: `SFCalendar` 위젯에 속성 `todayMark` 연결

**[4c82530](https://github.com/sniperfactory-official/sfac-designkit-flutter/pull/96/commits/4c825302c2197a54bf7d57d0f58f76209c27c634)**
변수명 변경 `SFCalendartStatus` ->  `SFCalendarType`

**[64d7112](https://github.com/sniperfactory-official/sfac-designkit-flutter/pull/96/commits/64d7112c3781a9a65c264f1169a7fa7ce4d9129a)**
`datePicker`: selectTextStyle 속성 삭제
`datePicker`: textColor -> calendarTextColor 속성 명 변경

**[d79d883](https://github.com/sniperfactory-official/sfac-designkit-flutter/pull/96/commits/d79d8836113e3e3c5d222bc9bbbc25faa3bed8f5)**
캘린더의 가로 폭이 길어지면 SFCalendarType.range일 때 선택한 기간의 마지막 날 배경 색 끊기는 오류 수정

## 리뷰어들에게 전달할 내용
확인 부탁드려요

<br/>
<br/>

```
특정 동작을 수행하는 다양한 키워드가 있지만
일단 'resolved' 혹은 'close'만 사용합니다.
ex) resolved: #issue_number (띄어쓰기 필수)
위의 예제처럼 입력할 시 merge를 할 경우 issue가 자동으로 close 됩니다
이 칸 아래에 적어주세요!
```
resolved: #49