### PR TITLE
juno, Feat:: Radio button prototype #99

### DIFF
--- a/lib/widgets/radiobutton/radio_button.dart
+++ b/lib/widgets/radiobutton/radio_button.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class SFRadioButton<T> extends StatefulWidget {
+  SFRadioButton({
+    Key? key,
+    required this.groupValue,
+    required this.onChanged,
+    required this.value,
+  }) : super(key: key);
+
+  final T groupValue;
+  final ValueChanged onChanged;
+  final T value;
+  @override
+  _SFRadioButtonState createState() => _SFRadioButtonState();
+}
+
+class _SFRadioButtonState<T> extends State<SFRadioButton<T>> {
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => widget.onChanged(widget.value),
+      child: Container(
+        width: 20,
+        height: 20,
+        margin: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          shape: BoxShape.circle,
+          border: Border.all(color: Colors.black87),
+        ),
+        child: Container(
+          margin: const EdgeInsets.all(2),
+          decoration: BoxDecoration(
+            color:
+                widget.groupValue == widget.value ? Colors.blue : Colors.white,
+            shape: BoxShape.circle,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/radiobutton/radio_button.dart
+++ b/lib/widgets/radiobutton/radio_button.dart
@@ -1,42 +1,85 @@
 import 'package:flutter/material.dart';
+import 'package:sfac_design_flutter/util/sfac_color.dart';
+
+enum SFRadioButtonType {
+  primary,
+}
 
 class SFRadioButton<T> extends StatefulWidget {
-  SFRadioButton({
+  const SFRadioButton({
     Key? key,
     required this.groupValue,
     required this.onChanged,
     required this.value,
+    this.type,
+    this.width = 16,
+    this.height = 16,
+    this.valueVisible = true,
+    this.valueSpacing = 8,
+    this.valueTextStyle = const TextStyle(
+      color: SFColor.grayScale80,
+    ),
   }) : super(key: key);
 
   final T groupValue;
   final ValueChanged onChanged;
   final T value;
+  final SFRadioButtonType? type;
+  final double? width;
+  final double? height;
+  final bool valueVisible;
+  final double valueSpacing;
+  final TextStyle? valueTextStyle;
   @override
   _SFRadioButtonState createState() => _SFRadioButtonState();
 }
 
 class _SFRadioButtonState<T> extends State<SFRadioButton<T>> {
+  Color _outlineColor = SFColor.grayScale100;
   @override
   Widget build(BuildContext context) {
+    switch (widget.type) {
+      case SFRadioButtonType.primary:
+        _outlineColor = SFColor.primary30;
+        break;
+      default:
+    }
+
     return GestureDetector(
       onTap: () => widget.onChanged(widget.value),
-      child: Container(
-        width: 20,
-        height: 20,
-        margin: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          shape: BoxShape.circle,
-          border: Border.all(color: Colors.black87),
-        ),
-        child: Container(
-          margin: const EdgeInsets.all(2),
-          decoration: BoxDecoration(
-            color:
-                widget.groupValue == widget.value ? Colors.blue : Colors.white,
-            shape: BoxShape.circle,
+      child: Row(
+        children: [
+          Container(
+            width: widget.width,
+            height: widget.height,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              border: Border.all(color: _outlineColor),
+            ),
+            child: Container(
+              margin: const EdgeInsets.all(2),
+              decoration: BoxDecoration(
+                color: widget.groupValue == widget.value
+                    ? SFColor.primary60
+                    : Colors.transparent,
+                shape: BoxShape.circle,
+              ),
+            ),
           ),
-        ),
+          widget.valueVisible
+              ? Row(
+                  children: [
+                    SizedBox(
+                      width: widget.valueSpacing,
+                    ),
+                    Text(
+                      widget.value.toString(),
+                      style: widget.valueTextStyle,
+                    ),
+                  ],
+                )
+              : const SizedBox.shrink()
+        ],
       ),
     );
   }

--- a/lib/widgets/radiobutton/radio_button.dart
+++ b/lib/widgets/radiobutton/radio_button.dart
@@ -2,18 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:sfac_design_flutter/util/sfac_color.dart';
 
 enum SFRadioButtonType {
+  basic,
   primary,
 }
 
 class SFRadioButton<T> extends StatefulWidget {
   const SFRadioButton({
     Key? key,
-    required this.groupValue,
+    required this.group,
     required this.onChanged,
     required this.value,
-    this.type,
-    this.width = 16,
-    this.height = 16,
+    this.type = SFRadioButtonType.basic,
+    this.size = 16,
+    this.circleSpacing = 2,
     this.valueVisible = true,
     this.valueSpacing = 8,
     this.valueTextStyle = const TextStyle(
@@ -21,28 +22,48 @@ class SFRadioButton<T> extends StatefulWidget {
     ),
   }) : super(key: key);
 
-  final T groupValue;
+  // Radio Button을 그룹화 시킬 값
+  final T group;
+
+  // Radio Button이 선택되었을 때 호출되는 이벤트 핸들러입니다.
+  // value는 Radio Button의 실제 값이며, 선택된 버튼의 value가 이 파라미터로 전달됨
   final ValueChanged onChanged;
+
+  // Radio Button의 값
   final T value;
-  final SFRadioButtonType? type;
-  final double? width;
-  final double? height;
+
+  // Radio Button의 타입으로 basic, primary가 있으며 현재 테두리 색의 변화만 있음
+  final SFRadioButtonType type;
+
+  // Radio Button의 크기
+  final double size;
+
+  // Radio Button 선택 시 테두리와 선택 표시 사이의 여백 크기
+  final double circleSpacing;
+
+  // Radio Button 우측에 value가 보이게 할 것인지의 여부
   final bool valueVisible;
+
+  // Radio Button과 value 사이의 여백
   final double valueSpacing;
+
+  // Radio Button 우측 value 텍스트의 스타일
   final TextStyle? valueTextStyle;
+
   @override
-  _SFRadioButtonState createState() => _SFRadioButtonState();
+  SFRadioButtonState createState() => SFRadioButtonState();
 }
 
-class _SFRadioButtonState<T> extends State<SFRadioButton<T>> {
+class SFRadioButtonState<T> extends State<SFRadioButton<T>> {
   Color _outlineColor = SFColor.grayScale100;
   @override
   Widget build(BuildContext context) {
     switch (widget.type) {
+      case SFRadioButtonType.basic:
+        break;
       case SFRadioButtonType.primary:
         _outlineColor = SFColor.primary30;
         break;
-      default:
     }
 
     return GestureDetector(
@@ -50,16 +71,18 @@ class _SFRadioButtonState<T> extends State<SFRadioButton<T>> {
       child: Row(
         children: [
           Container(
-            width: widget.width,
-            height: widget.height,
+            width: widget.size,
+            height: widget.size,
             decoration: BoxDecoration(
               shape: BoxShape.circle,
               border: Border.all(color: _outlineColor),
             ),
             child: Container(
-              margin: const EdgeInsets.all(2),
+              margin: EdgeInsets.all(
+                widget.circleSpacing,
+              ),
               decoration: BoxDecoration(
-                color: widget.groupValue == widget.value
+                color: widget.group == widget.value
                     ? SFColor.primary60
                     : Colors.transparent,
                 shape: BoxShape.circle,

--- a/lib/widgets/radiobutton/radio_button.dart
+++ b/lib/widgets/radiobutton/radio_button.dart
@@ -14,6 +14,7 @@ class SFRadioButton<T> extends StatefulWidget {
     required this.value,
     this.type = SFRadioButtonType.basic,
     this.size = 16,
+    this.margin = const EdgeInsets.all(8),
     this.circleSpacing = 2,
     this.valueVisible = true,
     this.valueSpacing = 8,
@@ -37,6 +38,9 @@ class SFRadioButton<T> extends StatefulWidget {
 
   // Radio Button의 크기
   final double size;
+
+  // Radio Button 바깥의 여백
+  final EdgeInsets margin;
 
   // Radio Button 선택 시 테두리와 선택 표시 사이의 여백 크기
   final double circleSpacing;
@@ -66,43 +70,46 @@ class SFRadioButtonState<T> extends State<SFRadioButton<T>> {
         break;
     }
 
-    return GestureDetector(
-      onTap: () => widget.onChanged(widget.value),
-      child: Row(
-        children: [
-          Container(
-            width: widget.size,
-            height: widget.size,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              border: Border.all(color: _outlineColor),
-            ),
-            child: Container(
-              margin: EdgeInsets.all(
-                widget.circleSpacing,
-              ),
+    return Container(
+      margin: widget.margin,
+      child: GestureDetector(
+        onTap: () => widget.onChanged(widget.value),
+        child: Row(
+          children: [
+            Container(
+              width: widget.size,
+              height: widget.size,
               decoration: BoxDecoration(
-                color: widget.group == widget.value
-                    ? SFColor.primary60
-                    : Colors.transparent,
                 shape: BoxShape.circle,
+                border: Border.all(color: _outlineColor),
+              ),
+              child: Container(
+                margin: EdgeInsets.all(
+                  widget.circleSpacing,
+                ),
+                decoration: BoxDecoration(
+                  color: widget.group == widget.value
+                      ? SFColor.primary60
+                      : Colors.transparent,
+                  shape: BoxShape.circle,
+                ),
               ),
             ),
-          ),
-          widget.valueVisible
-              ? Row(
-                  children: [
-                    SizedBox(
-                      width: widget.valueSpacing,
-                    ),
-                    Text(
-                      widget.value.toString(),
-                      style: widget.valueTextStyle,
-                    ),
-                  ],
-                )
-              : const SizedBox.shrink()
-        ],
+            widget.valueVisible
+                ? Row(
+                    children: [
+                      SizedBox(
+                        width: widget.valueSpacing,
+                      ),
+                      Text(
+                        widget.value.toString(),
+                        style: widget.valueTextStyle,
+                      ),
+                    ],
+                  )
+                : const SizedBox.shrink()
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## 요약 및 목적
radio button 위젯

## 변경사항에 대한 자세한 설명
같은 그룹일 경우(groupValue가 일치할 경우) 토글 형식으로 하나만 선택 가능합니다
사용시 같은 그룹으로 사용할 변수를 하나 작성하고
이를 groupValue에 넣어 사용합니다.
onChanged에서 작성한 변수 = v; 를 작성하고 setState를 통해 화면을 갱신해줍니다.

```
var selectNumber; // 변수 설정
.
.
.
 SFRadioButton(
                    groupValue: selectNumber,
                    onChanged: (v) {
                      setState(() {
                        selectNumber = v;
                      });
                    },
                    value: 1),
```

## 리뷰어들에게 전달할 내용
필요한 옵션들 의견 주세요
<br/>
<br/>

resolved: #99

