### PR TITLE
marco, Update:: 이미지 안나오는 오류 수정

### DIFF
--- a/lib/widgets/avatar/avatar.dart
+++ b/lib/widgets/avatar/avatar.dart
@@ -44,7 +44,7 @@ class SFAvatar extends StatelessWidget {
       ),
       child: ClipRRect(
           borderRadius: BorderRadius.circular(999),
-          child: child ?? SvgPicture.asset('images/logo.svg')),
+          child: child ?? SvgPicture.asset('packages/sfac_design_flutter/images/logo.svg')),
     );
   }
 }


### PR DESCRIPTION
## 요약 및 목적
기본 이미지 안나오는 오류 수정
## 변경사항에 대한 자세한 설명
SvgPicture.asset('images/logo.svg')에서
SvgPicture.asset('packages/sfac_design_flutter/images/logo.svg')로 경로변경했습니다
## 리뷰어들에게 전달할 내용
확인해주세요
<br/>
<br/>

```
특정 동작을 수행하는 다양한 키워드가 있지만
일단 'resolved' 혹은 'close'만 사용합니다.
ex) resolved: #issue_number (띄어쓰기 필수)
위의 예제처럼 입력할 시 merge를 할 경우 issue가 자동으로 close 됩니다
이 칸 아래에 적어주세요!
```
